### PR TITLE
Setup initial Next.js skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+viator-frontend/.next
+viator-frontend/out

--- a/viator-frontend/.eslintrc.json
+++ b/viator-frontend/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["airbnb-base", "prettier"],
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
+}

--- a/viator-frontend/.prettierrc
+++ b/viator-frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/viator-frontend/components/CommentForm.js
+++ b/viator-frontend/components/CommentForm.js
@@ -1,0 +1,10 @@
+export default function CommentForm() {
+  return (
+    <form className="space-y-2">
+      <textarea className="w-full border" rows="4" placeholder="Comment" />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/viator-frontend/components/Layout.js
+++ b/viator-frontend/components/Layout.js
@@ -1,0 +1,10 @@
+import Navbar from './Navbar';
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen p-4 bg-gray-50">{children}</main>
+    </>
+  );
+}

--- a/viator-frontend/components/Navbar.js
+++ b/viator-frontend/components/Navbar.js
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="p-4 bg-gray-800 text-white">
+      <ul className="flex space-x-4">
+        <li>
+          <Link href="/">Home</Link>
+        </li>
+        <li>
+          <Link href="/about">About</Link>
+        </li>
+        <li>
+          <Link href="/contact">Contact</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/viator-frontend/components/PostCard.js
+++ b/viator-frontend/components/PostCard.js
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function PostCard({ post }) {
+  return (
+    <div className="border p-4 rounded shadow">
+      <h2 className="text-xl font-bold">
+        <Link href={`/posts/${post.slug}`}>{post.title}</Link>
+      </h2>
+      <p>{post.excerpt}</p>
+    </div>
+  );
+}

--- a/viator-frontend/lib/api/rest.js
+++ b/viator-frontend/lib/api/rest.js
@@ -1,0 +1,5 @@
+export async function fetchPosts() {
+  const res = await fetch('/api/posts');
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}

--- a/viator-frontend/package.json
+++ b/viator-frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "viator-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "autoprefixer": "latest",
+    "postcss": "latest",
+    "tailwindcss": "latest",
+    "eslint": "latest",
+    "eslint-config-airbnb-base": "latest",
+    "eslint-plugin-import": "latest",
+    "prettier": "latest"
+  }
+}

--- a/viator-frontend/pages/_app.js
+++ b/viator-frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/viator-frontend/pages/about.js
+++ b/viator-frontend/pages/about.js
@@ -1,0 +1,12 @@
+import Layout from '../components/Layout';
+
+export default function About() {
+  return (
+    <Layout>
+      <div className="prose mx-auto">
+        <h1>About Viator</h1>
+        <p>Information about the blog.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/viator-frontend/pages/contact.js
+++ b/viator-frontend/pages/contact.js
@@ -1,0 +1,12 @@
+import Layout from '../components/Layout';
+
+export default function Contact() {
+  return (
+    <Layout>
+      <div className="prose mx-auto">
+        <h1>Contact</h1>
+        <p>Reach out via the form.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/viator-frontend/pages/index.js
+++ b/viator-frontend/pages/index.js
@@ -1,0 +1,12 @@
+import Layout from '../components/Layout';
+
+export default function Home() {
+  return (
+    <Layout>
+      <div className="prose mx-auto">
+        <h1>Welcome to Viator</h1>
+        <p>This is the home page.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/viator-frontend/pages/posts/[slug].js
+++ b/viator-frontend/pages/posts/[slug].js
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router';
+import Layout from '../../components/Layout';
+
+export default function Post() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  return (
+    <Layout>
+      <article className="prose mx-auto">
+        <h1>Post: {slug}</h1>
+        <p>Post content will go here.</p>
+      </article>
+    </Layout>
+  );
+}

--- a/viator-frontend/postcss.config.js
+++ b/viator-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/viator-frontend/styles/globals.css
+++ b/viator-frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/viator-frontend/tailwind.config.js
+++ b/viator-frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,jsx}',
+    './components/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/typography')],
+};


### PR DESCRIPTION
## Summary
- bootstrap a barebones Next.js project under `viator-frontend`
- configure Tailwind CSS and base lint/format settings
- add layout components and sample pages

## Testing
- `pnpm run build` *(fails: next not found)*
- `pnpm run lint` *(fails: ESLint config errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d6cfd16e88322a0142fd0b3563fc6